### PR TITLE
Reset RegExp position after each match

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ function include(file, text, includeRegExp, prefix, suffix, basePath) {
             new RegExp(escapeRegExp(prefix) + k + escapeRegExp(suffix), 'g'), data[k]);
       }
     }
+
+    includeRegExp.lastIndex = matches.index;
+
     matches = includeRegExp.exec(text);
   }
   file.contents = new Buffer(text);


### PR DESCRIPTION
You have this:

`index.js`
```javascript
'use strict';
#include('include1.js')
```

`include1.js`
```javascript
#include('second_include_file.js')
#include('third_include_file.js')
```

`second_include_file.js`
```javascript
alert('in second include');
```

`third_include_file.js`
```javascript
alert('in third include');
```

The current code gives you this:
```javascript
'use strict';
#include('second_include_file.js')
alert('in third include');
```

Why is this? Because the `RegExp.lastIndex` is set to the index of the last match + the length of that match&hellip; So we need to either insure that each included file starts with non-include instructions at least as long as the match that caused the file to be included, or we need to reset the `lastIndex` back to where the match was found.